### PR TITLE
Add prepare script to build package on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --project tsconfig.build.json && vite build",
+    "prepare": "npm run build",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",


### PR DESCRIPTION
## Summary
Adds a `prepare` npm script that automatically builds the package when installed from GitHub.

## Problem
When installing `basic_bot_react` directly from GitHub (e.g., `github:littlebee/basic_bot_react#main`), npm clones the repository but doesn't build the package. This causes CI/CD failures because the dist files referenced in package.json don't exist.

## Solution
The `prepare` script is an npm lifecycle hook that runs automatically after:
- `npm install` from git
- `npm link`
- Before `npm publish`

This ensures the package is always built and ready to use.

## Changes
- Added `"prepare": "npm run build"` to package.json scripts

## Testing
This will fix the CI/CD build failure in daphbot-due PR #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)