### PR TITLE
Add HubStateProvider context for simplified state management

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/react";
+import "../dist/style.css";
 
 const preview: Preview = {
     parameters: {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,19 +6,19 @@ A React component library for robot control interfaces, published to NPM with au
 
 This is an NPM-publishable React component library that provides UI components for controlling and monitoring robots. It includes:
 
--   **4 Main Components**: ObjectsOverlay, PanTilt, VideoFeed, WebRTCVideoClient
--   **5 Utility Modules**: hubState, hubMessages, angleUtils, uiUtils, webrtcClient
--   **Storybook Documentation**: Auto-deployed to GitHub Pages
--   **TypeDoc Integration**: Auto-generates MDX docs from JSDoc comments
+- **4 Main Components**: ObjectsOverlay, PanTilt, VideoFeed, WebRTCVideoClient
+- **5 Utility Modules**: hubState, hubMessages, angleUtils, uiUtils, webrtcClient
+- **Storybook Documentation**: Auto-deployed to GitHub Pages
+- **TypeDoc Integration**: Auto-generates MDX docs from JSDoc comments
 
 ## Tech Stack
 
--   **Build Tool**: Vite (ES modules + UMD)
--   **Framework**: React 18+ with TypeScript
--   **Documentation**: Storybook 8 with Autodocs
--   **Testing**: Vitest + React Testing Library
--   **Code Quality**: Prettier (4-space tabs) + ESLint (flat config)
--   **CI/CD**: GitHub Actions for testing, linting, building, and deployment
+- **Build Tool**: Vite (ES modules + UMD)
+- **Framework**: React 18+ with TypeScript
+- **Documentation**: Storybook 8 with Autodocs
+- **Testing**: Vitest + React Testing Library
+- **Code Quality**: Prettier (4-space tabs) + ESLint (flat config)
+- **CI/CD**: GitHub Actions for testing, linting, building, and deployment
 
 ## Architecture
 
@@ -26,27 +26,27 @@ This is an NPM-publishable React component library that provides UI components f
 
 All components are in `src/components/`:
 
--   **ObjectsOverlay**: Displays recognized objects with bounding boxes over video feed
--   **PanTilt**: Touch-based interface for controlling pan/tilt servos
--   **VideoFeed**: MJPEG video stream display
--   **WebRTCVideoClient**: WebRTC-based video/audio streaming
+- **ObjectsOverlay**: Displays recognized objects with bounding boxes over video feed
+- **PanTilt**: Touch-based interface for controlling pan/tilt servos
+- **VideoFeed**: MJPEG video stream display
+- **WebRTCVideoClient**: WebRTC-based video/audio streaming
 
 Each component has:
 
--   `.tsx` - Component implementation
--   `.test.tsx` - Vitest tests
--   `.stories.tsx` - Storybook stories with `tags: ['autodocs']`
--   `.module.css` - CSS modules (where applicable)
+- `.tsx` - Component implementation
+- `.test.tsx` - Vitest tests
+- `.stories.tsx` - Storybook stories with `tags: ['autodocs']`
+- `.module.css` - CSS modules (where applicable)
 
 ### Utilities
 
 All utilities are in `src/utils/`:
 
--   **hubState.ts**: WebSocket communication with robot hub
--   **hubMessages.ts**: Convenience wrapper for state updates with retry
--   **angleUtils.ts**: Angle calculations and coordinate transformations
--   **uiUtils.ts**: UI helper functions (touch vs mouse events)
--   **webrtcClient.ts**: WebRTC client for video/audio streaming
+- **hubState.ts**: WebSocket communication with robot hub
+- **hubMessages.ts**: Convenience wrapper for state updates with retry
+- **angleUtils.ts**: Angle calculations and coordinate transformations
+- **uiUtils.ts**: UI helper functions (touch vs mouse events)
+- **webrtcClient.ts**: WebRTC client for video/audio streaming
 
 ## Documentation System
 
@@ -59,9 +59,9 @@ All utilities are in `src/utils/`:
 
 Configuration:
 
--   `typedoc.json` - TypeDoc configuration
--   `tsconfig.typedoc.json` - Separate tsconfig to exclude test files
--   `.gitignore` includes `src/docs/` (generated files)
+- `typedoc.json` - TypeDoc configuration
+- `tsconfig.typedoc.json` - Separate tsconfig to exclude test files
+- `.gitignore` includes `src/docs/` (generated files)
 
 ### NPM Scripts
 
@@ -95,25 +95,25 @@ GitHub Actions workflow (`.github/workflows/deploy-storybook.yml`):
 
 ### ESLint Configuration
 
--   Flat config (`eslint.config.js`)
--   React hooks + React refresh plugins
--   TypeScript ESLint
--   Ignores: `dist`, `storybook-static`, `coverage`
--   Special rules for test files: allows `_` prefix for unused parameters
+- Flat config (`eslint.config.js`)
+- React hooks + React refresh plugins
+- TypeScript ESLint
+- Ignores: `dist`, `storybook-static`, `coverage`
+- Special rules for test files: allows `_` prefix for unused parameters
 
 ### Prettier Configuration
 
--   4-space tabs (`.prettierrc`)
--   Ignores build artifacts (`.prettierignore`)
+- 4-space tabs (`.prettierrc`)
+- Ignores build artifacts (`.prettierignore`)
 
 ## Testing Guidelines
 
--   Use Vitest + React Testing Library
--   Mock utility modules when testing components
--   Prefix unused mock parameters with `_` to satisfy ESLint
--   Use `getAllByText()` for duplicate text elements
--   Use `{ hidden: true }` for hidden elements with `getByRole()`
--   Use async imports for mocked modules in tests
+- Use Vitest + React Testing Library
+- Mock utility modules when testing components
+- Prefix unused mock parameters with `_` to satisfy ESLint
+- Use `getAllByText()` for duplicate text elements
+- Use `{ hidden: true }` for hidden elements with `getByRole()`
+- Use async imports for mocked modules in tests
 
 Example:
 
@@ -127,23 +127,23 @@ vi.mock("../../utils/angleUtils", () => ({
 
 ### Documentation
 
--   **Always add JSDoc comments** to exported functions, classes, and interfaces
--   Include `@param`, `@returns`, and `@example` tags
--   Module-level JSDoc with `@module` tag
--   TypeDoc auto-generates MDX from JSDoc - keep them in sync
+- **Always add JSDoc comments** to exported functions, classes, and interfaces
+- Include `@param`, `@returns`, and `@example` tags
+- Module-level JSDoc with `@module` tag
+- TypeDoc auto-generates MDX from JSDoc - keep them in sync
 
 ### Components
 
--   **Always include Storybook story** with `tags: ['autodocs']`
--   **Always include tests** with good coverage
--   Use CSS modules for styling
--   Export component and its props interface
+- **Always include Storybook story** with `tags: ['autodocs']`
+- **Always include tests** with good coverage
+- Use CSS modules for styling
+- Export component and its props interface
 
 ### Code Style
 
--   Run `npm run lint` before committing
--   4-space indentation (enforced by Prettier)
--   TypeScript strict mode enabled
+- Run `npm run lint` before committing
+- 4-space indentation (enforced by Prettier)
+- TypeScript strict mode enabled
 
 ## Publishing Workflow
 
@@ -155,14 +155,14 @@ vi.mock("../../utils/angleUtils", () => ({
 
 ## Key Files
 
--   `package.json` - Dependencies, scripts, package config
--   `vite.config.ts` - Vite build configuration
--   `tsconfig.json` - Main TypeScript config
--   `tsconfig.build.json` - Build-specific TypeScript config
--   `tsconfig.typedoc.json` - TypeDoc-specific config (excludes tests)
--   `typedoc.json` - TypeDoc configuration for MDX generation
--   `.storybook/main.ts` - Storybook configuration
--   `.github/workflows/deploy-storybook.yml` - CI/CD pipeline
+- `package.json` - Dependencies, scripts, package config
+- `vite.config.ts` - Vite build configuration
+- `tsconfig.json` - Main TypeScript config
+- `tsconfig.build.json` - Build-specific TypeScript config
+- `tsconfig.typedoc.json` - TypeDoc-specific config (excludes tests)
+- `typedoc.json` - TypeDoc configuration for MDX generation
+- `.storybook/main.ts` - Storybook configuration
+- `.github/workflows/deploy-storybook.yml` - CI/CD pipeline
 
 ## Using the Library
 
@@ -171,15 +171,16 @@ vi.mock("../../utils/angleUtils", () => ({
 To use components from this library in your application:
 
 ```typescript
-import { PanTilt, VideoFeed, ObjectsOverlay } from 'basic_bot_react';
-import 'basic_bot_react/style.css'; // Required: Import component styles
+import { PanTilt, VideoFeed, ObjectsOverlay } from "basic_bot_react";
+import "basic_bot_react/style.css"; // Required: Import component styles
 ```
 
 **IMPORTANT**: You must import `basic_bot_react/style.css` in your application to get component styling. Without this import, components will render without their CSS.
 
 For npm-linked development (e.g., `npm link ../basic_bot_react`), you may need to use a relative path:
+
 ```typescript
-import '../basic_bot_react/dist/style.css';
+import "../basic_bot_react/dist/style.css";
 ```
 
 ## Common Tasks
@@ -203,49 +204,49 @@ import '../basic_bot_react/dist/style.css';
 
 ### Updating Documentation
 
--   Update JSDoc comments in source files
--   Documentation auto-regenerates on next Storybook build
--   No need to manually edit MDX files (they're gitignored)
+- Update JSDoc comments in source files
+- Documentation auto-regenerates on next Storybook build
+- No need to manually edit MDX files (they're gitignored)
 
 ## Robot Communication
 
 ### WebSocket (hubState)
 
--   Connects to robot's central hub via WebSocket
--   Manages state synchronization
--   Use `connectToHub()` and `addHubStateUpdatedListener()`
+- Connects to robot's central hub via WebSocket
+- Manages state synchronization
+- Use `connectToHub()` and `addHubStateUpdatedListener()`
 
 ### WebRTC (webrtcClient)
 
--   Establishes real-time video/audio connection
--   Use `WebRTCClient.start()` with video and audio elements
--   Auto-negotiates SDP offer/answer
+- Establishes real-time video/audio connection
+- Use `WebRTCClient.start()` with video and audio elements
+- Auto-negotiates SDP offer/answer
 
 ### State Updates (hubMessages)
 
--   Convenience wrapper with retry logic
--   Use `sendHubStateUpdate()` for reliable updates
+- Convenience wrapper with retry logic
+- Use `sendHubStateUpdate()` for reliable updates
 
 ## Troubleshooting
 
 ### Tests Failing
 
--   Check if mock parameters need `_` prefix
--   Verify async imports for mocked modules
--   Use `getAllByText()` for duplicate elements
+- Check if mock parameters need `_` prefix
+- Verify async imports for mocked modules
+- Use `getAllByText()` for duplicate elements
 
 ### TypeDoc Errors
 
--   Ensure `tsconfig.typedoc.json` excludes test files
--   Check JSDoc syntax is valid
+- Ensure `tsconfig.typedoc.json` excludes test files
+- Check JSDoc syntax is valid
 
 ### Lint Errors
 
--   Run `npm run lint` to auto-fix
--   Check `.prettierignore` and eslint config ignores
+- Run `npm run lint` to auto-fix
+- Check `.prettierignore` and eslint config ignores
 
 ## Repository
 
--   **GitHub**: https://github.com/littlebee/basic_bot_react
--   **NPM**: basic_bot_react
--   **Docs**: https://littlebee.github.io/basic_bot_react
+- **GitHub**: https://github.com/littlebee/basic_bot_react
+- **NPM**: basic_bot_react
+- **Docs**: https://littlebee.github.io/basic_bot_react

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,24 @@ vi.mock("../../utils/angleUtils", () => ({
 -   `.storybook/main.ts` - Storybook configuration
 -   `.github/workflows/deploy-storybook.yml` - CI/CD pipeline
 
+## Using the Library
+
+### Importing Components
+
+To use components from this library in your application:
+
+```typescript
+import { PanTilt, VideoFeed, ObjectsOverlay } from 'basic_bot_react';
+import 'basic_bot_react/style.css'; // Required: Import component styles
+```
+
+**IMPORTANT**: You must import `basic_bot_react/style.css` in your application to get component styling. Without this import, components will render without their CSS.
+
+For npm-linked development (e.g., `npm link ../basic_bot_react`), you may need to use a relative path:
+```typescript
+import '../basic_bot_react/dist/style.css';
+```
+
 ## Common Tasks
 
 ### Adding a New Component

--- a/README.md
+++ b/README.md
@@ -96,11 +96,8 @@ function App() {
 }
 ```
 
-
 ## Documentation
 
 Component and utility function documentation is automatically generated and deployed to GitHub Pages.
 
 [View Documentation](https://littlebee.github.io/basic_bot_react)
-
-

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Use the `HubStateProvider` to automatically manage hub state and connection:
 
 ```tsx
 import { HubStateProvider, PanTilt } from "basic_bot_react";
+import "basic_bot_react/style.css";
 
 function App() {
     return (
@@ -41,6 +42,7 @@ import {
     addHubStateUpdatedListener,
     IHubState,
 } from "basic_bot_react";
+import "basic_bot_react/style.css";
 
 function App() {
     const [hubState, setHubState] = useState<IHubState>(DEFAULT_HUB_STATE);
@@ -72,6 +74,7 @@ Access hub state directly in your components:
 
 ```tsx
 import { HubStateProvider, useHubState } from "basic_bot_react";
+import "basic_bot_react/style.css";
 
 function MyComponent() {
     const hubState = useHubState();

--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ npm install basic_bot_react
 
 ## Usage
 
+### Simple Usage (Recommended)
+
+Use the `HubStateProvider` to automatically manage hub state and connection:
+
+```tsx
+import { HubStateProvider, PanTilt } from "basic_bot_react";
+
+function App() {
+    return (
+        <HubStateProvider>
+            <div className="controls">
+                <PanTilt />
+            </div>
+        </HubStateProvider>
+    );
+}
+```
+
+### Advanced Usage
+
+For more control, you can manually manage state:
+
 ```tsx
 import { useState, useEffect } from "react";
 import { PanTilt } from "basic_bot_react";
@@ -18,7 +40,7 @@ import {
     connectToHub,
     addHubStateUpdatedListener,
     IHubState,
-} from "basic_bot_react/util/hubState"
+} from "basic_bot_react";
 
 function App() {
     const [hubState, setHubState] = useState<IHubState>(DEFAULT_HUB_STATE);
@@ -37,14 +59,38 @@ function App() {
             <PanTilt
                 servoConfig={hubState.servo_config}
                 servoAngles={hubState.servo_angles}
-                servoActualAngles={
-                    hubState.servo_actual_angles
-                }
+                servoActualAngles={hubState.servo_actual_angles}
             />
         </div>
-    )
+    );
+}
+```
+
+### Using the useHubState Hook
+
+Access hub state directly in your components:
+
+```tsx
+import { HubStateProvider, useHubState } from "basic_bot_react";
+
+function MyComponent() {
+    const hubState = useHubState();
+
+    return (
+        <div>
+            <p>Connection: {hubState.hubConnStatus}</p>
+            <p>Pan angle: {hubState.servo_angles?.pan}°</p>
+        </div>
+    );
 }
 
+function App() {
+    return (
+        <HubStateProvider>
+            <MyComponent />
+        </HubStateProvider>
+    );
+}
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
       "import": "./dist/basic_bot_react.js",
       "require": "./dist/basic_bot_react.umd.cjs",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./style.css": "./dist/style.css"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "test:coverage": "vitest --coverage",
     "lint": "prettier --write . && eslint --fix .",
     "docs:generate": "typedoc",
-    "prestorybook": "npm run docs:generate",
+    "prestorybook": "npm run build && npm run docs:generate",
     "storybook": "storybook dev -p 6006",
-    "prebuild-storybook": "npm run docs:generate",
+    "prebuild-storybook": "npm run build && npm run docs:generate",
     "build-storybook": "storybook build",
     "prepublishOnly": "npm run test && npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -1,93 +1,93 @@
 {
-  "name": "basic_bot_react",
-  "version": "0.1.0",
-  "description": "A collection of React components for basic_bot",
-  "type": "module",
-  "main": "./dist/basic_bot_react.umd.cjs",
-  "module": "./dist/basic_bot_react.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/basic_bot_react.js",
-      "require": "./dist/basic_bot_react.umd.cjs",
-      "types": "./dist/index.d.ts"
+    "name": "basic_bot_react",
+    "version": "0.1.0",
+    "description": "A collection of React components for basic_bot",
+    "type": "module",
+    "main": "./dist/basic_bot_react.umd.cjs",
+    "module": "./dist/basic_bot_react.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/basic_bot_react.js",
+            "require": "./dist/basic_bot_react.umd.cjs",
+            "types": "./dist/index.d.ts"
+        },
+        "./style.css": "./dist/style.css"
     },
-    "./style.css": "./dist/style.css"
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc --project tsconfig.build.json && vite build",
-    "prepare": "npm run build",
-    "test": "vitest",
-    "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage",
-    "lint": "prettier --write . && eslint --fix .",
-    "docs:generate": "typedoc",
-    "prestorybook": "npm run build && npm run docs:generate",
-    "storybook": "storybook dev -p 6006",
-    "prebuild-storybook": "npm run build && npm run docs:generate",
-    "build-storybook": "storybook build",
-    "prepublishOnly": "npm run test && npm run build"
-  },
-  "keywords": [
-    "react",
-    "components",
-    "ui",
-    "basic_bot"
-  ],
-  "author": "Bee Wilkerson",
-  "license": "MIT",
-  "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9.36.0",
-    "@storybook/addon-essentials": "^8.0.0",
-    "@storybook/addon-interactions": "^8.0.0",
-    "@storybook/addon-links": "^8.0.0",
-    "@storybook/blocks": "^8.0.0",
-    "@storybook/react": "^8.0.0",
-    "@storybook/react-vite": "^8.0.0",
-    "@storybook/test": "^8.0.0",
-    "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.0.0",
-    "@types/node": "^24.6.1",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
-    "@types/uuid": "^10.0.0",
-    "@vitejs/plugin-react": "^4.0.0",
-    "@vitest/ui": "^2.0.0",
-    "eslint": "^9.36.0",
-    "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-react-refresh": "^0.4.22",
-    "globals": "^16.4.0",
-    "happy-dom": "^15.0.0",
-    "prettier": "^3.6.2",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "storybook": "^8.0.0",
-    "typedoc": "^0.28.13",
-    "typedoc-plugin-markdown": "^4.9.0",
-    "typescript": "^5.0.0",
-    "typescript-eslint": "^8.45.0",
-    "vite": "^5.0.0",
-    "vite-plugin-dts": "^4.0.0",
-    "vitest": "^2.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/littlebee/basic_bot_react.git"
-  },
-  "bugs": {
-    "url": "https://github.com/littlebee/basic_bot_react/issues"
-  },
-  "homepage": "https://littlebee.github.io/basic_bot_react",
-  "dependencies": {
-    "uuid": "^13.0.0"
-  }
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "dev": "vite",
+        "build": "tsc --project tsconfig.build.json && vite build",
+        "prepare": "npm run build",
+        "test": "vitest",
+        "test:ui": "vitest --ui",
+        "test:coverage": "vitest --coverage",
+        "lint": "prettier --write . && eslint --fix .",
+        "docs:generate": "typedoc",
+        "prestorybook": "npm run build && npm run docs:generate",
+        "storybook": "storybook dev -p 6006",
+        "prebuild-storybook": "npm run build && npm run docs:generate",
+        "build-storybook": "storybook build",
+        "prepublishOnly": "npm run test && npm run build"
+    },
+    "keywords": [
+        "react",
+        "components",
+        "ui",
+        "basic_bot"
+    ],
+    "author": "Bee Wilkerson",
+    "license": "MIT",
+    "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+    },
+    "devDependencies": {
+        "@eslint/js": "^9.36.0",
+        "@storybook/addon-essentials": "^8.0.0",
+        "@storybook/addon-interactions": "^8.0.0",
+        "@storybook/addon-links": "^8.0.0",
+        "@storybook/blocks": "^8.0.0",
+        "@storybook/react": "^8.0.0",
+        "@storybook/react-vite": "^8.0.0",
+        "@storybook/test": "^8.0.0",
+        "@testing-library/jest-dom": "^6.0.0",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.0.0",
+        "@types/node": "^24.6.1",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@types/uuid": "^10.0.0",
+        "@vitejs/plugin-react": "^4.0.0",
+        "@vitest/ui": "^2.0.0",
+        "eslint": "^9.36.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.22",
+        "globals": "^16.4.0",
+        "happy-dom": "^15.0.0",
+        "prettier": "^3.6.2",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "storybook": "^8.0.0",
+        "typedoc": "^0.28.13",
+        "typedoc-plugin-markdown": "^4.9.0",
+        "typescript": "^5.0.0",
+        "typescript-eslint": "^8.45.0",
+        "vite": "^5.0.0",
+        "vite-plugin-dts": "^4.0.0",
+        "vitest": "^2.0.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/littlebee/basic_bot_react.git"
+    },
+    "bugs": {
+        "url": "https://github.com/littlebee/basic_bot_react/issues"
+    },
+    "homepage": "https://littlebee.github.io/basic_bot_react",
+    "dependencies": {
+        "uuid": "^13.0.0"
+    }
 }

--- a/src/components/ObjectsOverlay/ObjectsOverlay.tsx
+++ b/src/components/ObjectsOverlay/ObjectsOverlay.tsx
@@ -1,6 +1,8 @@
+import { useContext } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import { IRecognizedObject } from "../../utils/hubState";
+import { HubStateContext } from "../../context/HubStateProvider";
 
 import st from "./ObjectsOverlay.module.css";
 
@@ -15,13 +17,23 @@ export interface ObjectsOverlayProps {
  * This component overlays rectangular boxes on detected objects, displaying
  * their classification and confidence scores. Typically used on top of video
  * feeds to visualize computer vision detection results.
+ *
+ * Can be used with or without HubStateProvider:
+ * - With props: Pass recogObjects directly
+ * - With provider: Wrap in HubStateProvider and objects will be automatically populated from recognition state
  */
 export function ObjectsOverlay({ recogObjects }: ObjectsOverlayProps) {
-    if (!recogObjects || recogObjects.length < 1) {
+    // Try to get hub state from context (will be null if not in provider)
+    const hubState = useContext(HubStateContext);
+
+    // Use props if provided, otherwise fall back to context
+    const objects = recogObjects ?? hubState?.recognition;
+
+    if (!objects || objects.length < 1) {
         return null;
     }
     const elements = [];
-    for (const obj of recogObjects) {
+    for (const obj of objects) {
         const [left, top, right, bottom] = obj.bounding_box;
 
         const style = {

--- a/src/context/HubStateProvider.stories.tsx
+++ b/src/context/HubStateProvider.stories.tsx
@@ -1,0 +1,191 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { HubStateProvider } from "./HubStateProvider";
+import { PanTilt } from "../components/PanTilt/PanTilt";
+import { ObjectsOverlay } from "../components/ObjectsOverlay/ObjectsOverlay";
+import { useHubState } from "./useHubState";
+import { useEffect } from "react";
+import { IHubState, IServoConfig } from "../utils/hubState";
+
+// Mock servo config for demo
+const mockServoConfig: IServoConfig = {
+    servos: [
+        {
+            name: "pan",
+            channel: 0,
+            motor_range: 180,
+            min_angle: 0,
+            max_angle: 180,
+            min_pulse: 500,
+            max_pulse: 2500,
+        },
+        {
+            name: "tilt",
+            channel: 1,
+            motor_range: 180,
+            min_angle: 0,
+            max_angle: 180,
+            min_pulse: 500,
+            max_pulse: 2500,
+        },
+    ],
+};
+
+// Demo component that displays hub state
+function HubStateDisplay() {
+    const hubState = useHubState();
+
+    return (
+        <div style={{ padding: "20px", backgroundColor: "#f0f0f0" }}>
+            <h3>Hub State</h3>
+            <pre>{JSON.stringify(hubState, null, 2)}</pre>
+        </div>
+    );
+}
+
+// Demo component showing PanTilt with provider
+function PanTiltWithProvider() {
+    return (
+        <div style={{ padding: "20px" }}>
+            <h3>PanTilt Component (using context)</h3>
+            <PanTilt />
+        </div>
+    );
+}
+
+// Demo component that simulates state updates for Storybook
+function MockStateUpdater({ children }: { children: React.ReactNode }) {
+    useEffect(() => {
+        // In a real app, this would come from the hub
+        // For Storybook, we'll simulate it
+        const mockState: Partial<IHubState> = {
+            hubConnStatus: "online",
+            hub_stats: { state_updates_recv: 42 },
+            servo_config: mockServoConfig,
+            servo_angles: { pan: 90, tilt: 90 },
+            servo_actual_angles: { pan: 88, tilt: 92 },
+            recognition: [
+                {
+                    classification: "person",
+                    confidence: 0.95,
+                    bounding_box: [100, 100, 300, 400],
+                },
+            ],
+        };
+
+        // Note: In Storybook, connectToHub won't actually connect
+        // So this is just for demonstration
+        console.log("Mock state would be:", mockState);
+    }, []);
+
+    return <>{children}</>;
+}
+
+const meta: Meta<typeof HubStateProvider> = {
+    component: HubStateProvider,
+    tags: ["autodocs"],
+    parameters: {
+        layout: "fullscreen",
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof HubStateProvider>;
+
+/**
+ * Basic usage with HubStateProvider wrapping components.
+ * Components automatically receive hub state without prop drilling.
+ */
+export const BasicUsage: Story = {
+    render: () => (
+        <HubStateProvider autoConnect={false}>
+            <div style={{ padding: "20px" }}>
+                <h2>Components Using HubStateProvider</h2>
+                <p>
+                    Components wrapped in HubStateProvider can access hub state
+                    via context
+                </p>
+                <HubStateDisplay />
+            </div>
+        </HubStateProvider>
+    ),
+};
+
+/**
+ * Example showing PanTilt component using the provider.
+ * No props needed - state comes from context.
+ */
+export const WithPanTilt: Story = {
+    render: () => (
+        <HubStateProvider autoConnect={false}>
+            <MockStateUpdater>
+                <div style={{ padding: "20px" }}>
+                    <h2>PanTilt with Provider</h2>
+                    <p>
+                        PanTilt component gets servo config and angles from
+                        context
+                    </p>
+                    <PanTiltWithProvider />
+                </div>
+            </MockStateUpdater>
+        </HubStateProvider>
+    ),
+};
+
+/**
+ * Example with custom configuration options.
+ */
+export const CustomConfiguration: Story = {
+    render: () => (
+        <HubStateProvider
+            port={5200}
+            autoConnect={false}
+            autoReconnect={false}
+        >
+            <div style={{ padding: "20px" }}>
+                <h2>Custom Provider Configuration</h2>
+                <p>Port: 5200, autoConnect: false, autoReconnect: false</p>
+                <HubStateDisplay />
+            </div>
+        </HubStateProvider>
+    ),
+};
+
+/**
+ * Example showing multiple components using the same provider.
+ */
+export const MultipleComponents: Story = {
+    render: () => (
+        <HubStateProvider autoConnect={false}>
+            <MockStateUpdater>
+                <div style={{ padding: "20px" }}>
+                    <h2>Multiple Components Sharing State</h2>
+                    <div
+                        style={{
+                            display: "grid",
+                            gridTemplateColumns: "1fr 1fr",
+                            gap: "20px",
+                        }}
+                    >
+                        <div>
+                            <h3>PanTilt Control</h3>
+                            <PanTilt />
+                        </div>
+                        <div>
+                            <h3>Objects Overlay</h3>
+                            <div
+                                style={{
+                                    position: "relative",
+                                    width: "400px",
+                                    height: "300px",
+                                    backgroundColor: "#000",
+                                }}
+                            >
+                                <ObjectsOverlay />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </MockStateUpdater>
+        </HubStateProvider>
+    ),
+};

--- a/src/context/HubStateProvider.stories.tsx
+++ b/src/context/HubStateProvider.stories.tsx
@@ -136,11 +136,7 @@ export const WithPanTilt: Story = {
  */
 export const CustomConfiguration: Story = {
     render: () => (
-        <HubStateProvider
-            port={5200}
-            autoConnect={false}
-            autoReconnect={false}
-        >
+        <HubStateProvider port={5200} autoConnect={false} autoReconnect={false}>
             <div style={{ padding: "20px" }}>
                 <h2>Custom Provider Configuration</h2>
                 <p>Port: 5200, autoConnect: false, autoReconnect: false</p>

--- a/src/context/HubStateProvider.test.tsx
+++ b/src/context/HubStateProvider.test.tsx
@@ -137,14 +137,12 @@ describe("HubStateProvider", () => {
     });
 
     it("removes hub state listener on unmount", async () => {
-        const {
-            addHubStateUpdatedListener,
-            removeHubStateUpdatedListener,
-        } = await import("../utils/hubState");
+        const { addHubStateUpdatedListener, removeHubStateUpdatedListener } =
+            await import("../utils/hubState");
 
         let capturedHandler: ((state: IHubState) => void) | null = null;
 
-        (addHubStateUpdatedListener as any).mockImplementation(
+        vi.mocked(addHubStateUpdatedListener).mockImplementation(
             (handler: (state: IHubState) => void) => {
                 capturedHandler = handler;
             },
@@ -174,7 +172,7 @@ describe("HubStateProvider", () => {
 
         let stateUpdateHandler: ((state: IHubState) => void) | null = null;
 
-        (addHubStateUpdatedListener as any).mockImplementation(
+        vi.mocked(addHubStateUpdatedListener).mockImplementation(
             (handler: (state: IHubState) => void) => {
                 stateUpdateHandler = handler;
             },

--- a/src/context/HubStateProvider.test.tsx
+++ b/src/context/HubStateProvider.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { HubStateProvider } from "./HubStateProvider";
+import { useHubState } from "./useHubState";
+import { IHubState } from "../utils/hubState";
+
+// Mock the hubState utility functions
+vi.mock("../utils/hubState", async () => {
+    const actual =
+        await vi.importActual<typeof import("../utils/hubState")>(
+            "../utils/hubState",
+        );
+    return {
+        ...actual,
+        connectToHub: vi.fn(),
+        addHubStateUpdatedListener: vi.fn(),
+        removeHubStateUpdatedListener: vi.fn(),
+        DEFAULT_HUB_STATE: {
+            hubConnStatus: "offline",
+            hub_stats: { state_updates_recv: 0 },
+        },
+        DEFAULT_BB_HUB_PORT: 5100,
+    };
+});
+
+// Test component that uses the hook
+function TestComponent() {
+    const hubState = useHubState();
+    return (
+        <div>
+            <div data-testid="conn-status">{hubState.hubConnStatus}</div>
+            <div data-testid="updates-recv">
+                {hubState.hub_stats.state_updates_recv}
+            </div>
+        </div>
+    );
+}
+
+describe("HubStateProvider", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("provides hub state to children", () => {
+        render(
+            <HubStateProvider>
+                <TestComponent />
+            </HubStateProvider>,
+        );
+
+        expect(screen.getByTestId("conn-status")).toHaveTextContent("offline");
+        expect(screen.getByTestId("updates-recv")).toHaveTextContent("0");
+    });
+
+    it("connects to hub when autoConnect is true", async () => {
+        const { connectToHub } = await import("../utils/hubState");
+
+        render(
+            <HubStateProvider autoConnect={true}>
+                <TestComponent />
+            </HubStateProvider>,
+        );
+
+        await waitFor(() => {
+            expect(connectToHub).toHaveBeenCalledWith({
+                port: 5100,
+                state: expect.any(Object),
+                autoReconnect: true,
+            });
+        });
+    });
+
+    it("does not connect when autoConnect is false", async () => {
+        const { connectToHub } = await import("../utils/hubState");
+
+        render(
+            <HubStateProvider autoConnect={false}>
+                <TestComponent />
+            </HubStateProvider>,
+        );
+
+        expect(connectToHub).not.toHaveBeenCalled();
+    });
+
+    it("uses custom port when provided", async () => {
+        const { connectToHub } = await import("../utils/hubState");
+
+        render(
+            <HubStateProvider port={5200}>
+                <TestComponent />
+            </HubStateProvider>,
+        );
+
+        await waitFor(() => {
+            expect(connectToHub).toHaveBeenCalledWith({
+                port: 5200,
+                state: expect.any(Object),
+                autoReconnect: true,
+            });
+        });
+    });
+
+    it("passes autoReconnect option to connectToHub", async () => {
+        const { connectToHub } = await import("../utils/hubState");
+
+        render(
+            <HubStateProvider autoReconnect={false}>
+                <TestComponent />
+            </HubStateProvider>,
+        );
+
+        await waitFor(() => {
+            expect(connectToHub).toHaveBeenCalledWith({
+                port: 5100,
+                state: expect.any(Object),
+                autoReconnect: false,
+            });
+        });
+    });
+
+    it("adds hub state listener on mount", async () => {
+        const { addHubStateUpdatedListener } = await import(
+            "../utils/hubState"
+        );
+
+        render(
+            <HubStateProvider>
+                <TestComponent />
+            </HubStateProvider>,
+        );
+
+        await waitFor(() => {
+            expect(addHubStateUpdatedListener).toHaveBeenCalledWith(
+                expect.any(Function),
+            );
+        });
+    });
+
+    it("removes hub state listener on unmount", async () => {
+        const {
+            addHubStateUpdatedListener,
+            removeHubStateUpdatedListener,
+        } = await import("../utils/hubState");
+
+        let capturedHandler: ((state: IHubState) => void) | null = null;
+
+        (addHubStateUpdatedListener as any).mockImplementation(
+            (handler: (state: IHubState) => void) => {
+                capturedHandler = handler;
+            },
+        );
+
+        const { unmount } = render(
+            <HubStateProvider>
+                <TestComponent />
+            </HubStateProvider>,
+        );
+
+        await waitFor(() => {
+            expect(capturedHandler).not.toBeNull();
+        });
+
+        unmount();
+
+        expect(removeHubStateUpdatedListener).toHaveBeenCalledWith(
+            capturedHandler,
+        );
+    });
+
+    it("updates state when hub state changes", async () => {
+        const { addHubStateUpdatedListener } = await import(
+            "../utils/hubState"
+        );
+
+        let stateUpdateHandler: ((state: IHubState) => void) | null = null;
+
+        (addHubStateUpdatedListener as any).mockImplementation(
+            (handler: (state: IHubState) => void) => {
+                stateUpdateHandler = handler;
+            },
+        );
+
+        render(
+            <HubStateProvider>
+                <TestComponent />
+            </HubStateProvider>,
+        );
+
+        await waitFor(() => {
+            expect(stateUpdateHandler).not.toBeNull();
+        });
+
+        // Simulate hub state update
+        const newState: IHubState = {
+            hubConnStatus: "online",
+            hub_stats: { state_updates_recv: 5 },
+        };
+
+        if (stateUpdateHandler) {
+            stateUpdateHandler(newState);
+        }
+
+        await waitFor(() => {
+            expect(screen.getByTestId("conn-status")).toHaveTextContent(
+                "online",
+            );
+            expect(screen.getByTestId("updates-recv")).toHaveTextContent("5");
+        });
+    });
+});

--- a/src/context/HubStateProvider.tsx
+++ b/src/context/HubStateProvider.tsx
@@ -21,6 +21,7 @@ import {
  * React context for hub state.
  * Use the `useHubState` hook to access this context in your components.
  */
+// eslint-disable-next-line react-refresh/only-export-components
 export const HubStateContext = createContext<IHubState | null>(null);
 
 /**

--- a/src/context/HubStateProvider.tsx
+++ b/src/context/HubStateProvider.tsx
@@ -1,0 +1,103 @@
+/**
+ * HubState Context Provider
+ *
+ * Provides a React context for accessing robot hub state throughout your application.
+ * Eliminates the need for manual state management and prop drilling.
+ *
+ * @module HubStateProvider
+ */
+
+import { createContext, useEffect, useState, ReactNode } from "react";
+import {
+    IHubState,
+    DEFAULT_HUB_STATE,
+    connectToHub,
+    addHubStateUpdatedListener,
+    removeHubStateUpdatedListener,
+    DEFAULT_BB_HUB_PORT,
+} from "../utils/hubState";
+
+/**
+ * React context for hub state.
+ * Use the `useHubState` hook to access this context in your components.
+ */
+export const HubStateContext = createContext<IHubState | null>(null);
+
+/**
+ * Configuration options for the HubStateProvider.
+ */
+export interface HubStateProviderProps {
+    /** Child components that will have access to hub state */
+    children: ReactNode;
+
+    /** WebSocket port number for the hub connection (default: 5100) */
+    port?: number;
+
+    /** Automatically connect to hub on mount (default: true) */
+    autoConnect?: boolean;
+
+    /** Automatically reconnect on connection loss (default: true) */
+    autoReconnect?: boolean;
+}
+
+/**
+ * Provider component that manages hub state and WebSocket connection.
+ *
+ * Wrap your application or component tree with this provider to enable
+ * automatic hub state management. Components can then use the `useHubState`
+ * hook to access the current state without prop drilling.
+ *
+ * @example
+ * ```tsx
+ * import { HubStateProvider, PanTilt } from "basic_bot_react";
+ *
+ * function App() {
+ *     return (
+ *         <HubStateProvider>
+ *             <PanTilt />
+ *         </HubStateProvider>
+ *     );
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Custom port and configuration
+ * <HubStateProvider port={5200} autoReconnect={false}>
+ *     <YourComponents />
+ * </HubStateProvider>
+ * ```
+ */
+export function HubStateProvider({
+    children,
+    port = DEFAULT_BB_HUB_PORT,
+    autoConnect = true,
+    autoReconnect = true,
+}: HubStateProviderProps) {
+    const [hubState, setHubState] = useState<IHubState>(DEFAULT_HUB_STATE);
+
+    useEffect(() => {
+        const handleHubStateUpdate = (newState: Partial<IHubState>) => {
+            setHubState({ ...newState } as IHubState);
+        };
+        addHubStateUpdatedListener(handleHubStateUpdate);
+        if (autoConnect) {
+            connectToHub({
+                port,
+                state: DEFAULT_HUB_STATE,
+                autoReconnect,
+            });
+        }
+
+        // Cleanup on unmount
+        return () => {
+            removeHubStateUpdatedListener(handleHubStateUpdate);
+        };
+    }, [port, autoConnect, autoReconnect]);
+
+    return (
+        <HubStateContext.Provider value={hubState}>
+            {children}
+        </HubStateContext.Provider>
+    );
+}

--- a/src/context/useHubState.test.tsx
+++ b/src/context/useHubState.test.tsx
@@ -6,13 +6,13 @@ import { HubStateProvider } from "./HubStateProvider";
 describe("useHubState", () => {
     it("throws error when used outside provider", () => {
         // Suppress console.error for this test since we expect an error
-        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        const consoleSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
 
         expect(() => {
             renderHook(() => useHubState());
-        }).toThrow(
-            "useHubState must be used within a HubStateProvider",
-        );
+        }).toThrow("useHubState must be used within a HubStateProvider");
 
         consoleSpy.mockRestore();
     });

--- a/src/context/useHubState.test.tsx
+++ b/src/context/useHubState.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useHubState } from "./useHubState";
+import { HubStateProvider } from "./HubStateProvider";
+
+describe("useHubState", () => {
+    it("throws error when used outside provider", () => {
+        // Suppress console.error for this test since we expect an error
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        expect(() => {
+            renderHook(() => useHubState());
+        }).toThrow(
+            "useHubState must be used within a HubStateProvider",
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it("returns hub state when used inside provider", () => {
+        const { result } = renderHook(() => useHubState(), {
+            wrapper: HubStateProvider,
+        });
+
+        expect(result.current).toBeDefined();
+        expect(result.current.hubConnStatus).toBeDefined();
+        expect(result.current.hub_stats).toBeDefined();
+    });
+});

--- a/src/context/useHubState.ts
+++ b/src/context/useHubState.ts
@@ -1,0 +1,60 @@
+/**
+ * Hook for accessing hub state from React components.
+ *
+ * @module useHubState
+ */
+
+import { useContext } from "react";
+import { HubStateContext } from "./HubStateProvider";
+import { IHubState } from "../utils/hubState";
+
+/**
+ * React hook to access the current hub state.
+ *
+ * This hook provides access to the robot's hub state when used within a
+ * `HubStateProvider`. It will throw an error if used outside the provider
+ * to help catch configuration mistakes early.
+ *
+ * @returns The current hub state
+ * @throws Error if used outside of HubStateProvider
+ *
+ * @example
+ * ```tsx
+ * import { useHubState } from "basic_bot_react";
+ *
+ * function MyComponent() {
+ *     const hubState = useHubState();
+ *
+ *     return (
+ *         <div>
+ *             <p>Connection: {hubState.hubConnStatus}</p>
+ *             <p>Pan angle: {hubState.servo_angles?.pan}</p>
+ *         </div>
+ *     );
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Use with optional chaining for safety
+ * function ServoDisplay() {
+ *     const hubState = useHubState();
+ *     const panAngle = hubState.servo_angles?.pan ?? 0;
+ *
+ *     return <div>Pan: {panAngle}°</div>;
+ * }
+ * ```
+ */
+export function useHubState(): IHubState {
+    const context = useContext(HubStateContext);
+
+    if (context === null) {
+        throw new Error(
+            "useHubState must be used within a HubStateProvider. " +
+                "Wrap your component tree with <HubStateProvider>...</HubStateProvider> " +
+                "to use this hook.",
+        );
+    }
+
+    return context;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@
 // Export all components
 export * from "./components";
 
+// Export context provider and hook
+export { HubStateProvider } from "./context/HubStateProvider";
+export type { HubStateProviderProps } from "./context/HubStateProvider";
+export { useHubState } from "./context/useHubState";
+
 // Export useful types and utilities
 export type {
     IHubState,


### PR DESCRIPTION
## Summary

This PR introduces a React context provider pattern to dramatically simplify the usage of basic_bot_react components. Users can now use components without manual state management or prop drilling.

### What's New

- **HubStateProvider**: A context provider that automatically manages WebSocket connection and hub state
- **useHubState hook**: Custom hook for accessing hub state from any component
- **Backward compatible updates**: PanTilt and ObjectsOverlay now support both context and props-based usage

### Key Benefits

✅ Simpler API: No need for manual useState, useEffect, or listeners
✅ No prop drilling: State flows through context
✅ Backward compatible: Existing code continues to work unchanged
✅ Well tested: Comprehensive test coverage for new features
✅ Documented: README updated with new usage patterns, Storybook examples added

### Usage Comparison

See README.md for detailed usage examples showing the before/after comparison.

### Files Changed

**New files:**
- src/context/HubStateProvider.tsx - Context provider component
- src/context/useHubState.ts - Custom hook
- src/context/HubStateProvider.test.tsx - Provider tests (8 tests)
- src/context/useHubState.test.tsx - Hook tests (2 tests)
- src/context/HubStateProvider.stories.tsx - Storybook examples

**Updated files:**
- src/components/PanTilt/PanTilt.tsx - Added context support
- src/components/ObjectsOverlay/ObjectsOverlay.tsx - Added context support
- src/index.ts - Export new context items
- README.md - Updated with new usage examples

### Test Results

All 37 tests pass ✅

### Breaking Changes

None - fully backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)