### PR TITLE
className props for everyone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ vi.mock("../../utils/angleUtils", () => ({
 - **Always include tests** with good coverage
 - Use CSS modules for styling
 - Export component and its props interface
+- Always include a "className" prop that gets appended to outer container
+- All css module class names for the outer most container element should be named like `bbr{ComponentName}Container` so PanTilt component's outer element class is `.bbrPanTiltContainer`
 
 ### Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,9 @@ vi.mock("../../utils/angleUtils", () => ({
 - **Always include tests** with good coverage
 - Use CSS modules for styling
 - Export component and its props interface
-- Always include a "className" prop that gets appended to outer container
-- All css module class names for the outer most container element should be named like `bbr{ComponentName}Container` so PanTilt component's outer element class is `.bbrPanTiltContainer`
+- Always include a "className" prop on new components that gets appended to outer container
+- All css module class names for the outer most container element should be named like `bbr{ComponentName}` so PanTilt component's outer element class is `.bbrPanTilt`
+- Avoid arbitrary changing of `className`s on inner elements in component as they may be overridden by user of basic_bot_react library.
 
 ### Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,3 +106,12 @@ export const Primary: Story = {
 2. Run tests and build: `npm run prepublishOnly`
 3. Login to NPM: `npm login`
 4. Publish: `npm publish --access public`
+
+
+## CSS
+- Use [css modules](https://www.w3schools.com/react/react_css_modules.asp)
+- Always include a "className" prop on new components that gets appended to outer container
+- All css module class names for the outer most container element should be named like `bbr{ComponentName}` so PanTilt component's outer element class is `.bbrPanTilt`
+- Avoid arbitrary changing of `className`s on inner elements in component as they may be overridden by user of basic_bot_react library.
+- Avoid arbitrary changing of `className`s on inner elements in component as they may be overridden by user of basic_bot_react library.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,5 +113,4 @@ export const Primary: Story = {
 - Always include a "className" prop on new components that gets appended to outer container
 - All css module class names for the outer most container element should be named like `bbr{ComponentName}` so PanTilt component's outer element class is `.bbrPanTilt`
 - Avoid arbitrary changing of `className`s on inner elements in component as they may be overridden by user of basic_bot_react library.
-- Avoid arbitrary changing of `className`s on inner elements in component as they may be overridden by user of basic_bot_react library.
 

--- a/src/components/ObjectsOverlay/ObjectsOverlay.module.css
+++ b/src/components/ObjectsOverlay/ObjectsOverlay.module.css
@@ -1,4 +1,4 @@
-.wrapper {
+.bbrObjectsOverlay {
     position: absolute;
     z-index: 1;
 }

--- a/src/components/ObjectsOverlay/ObjectsOverlay.tsx
+++ b/src/components/ObjectsOverlay/ObjectsOverlay.tsx
@@ -9,6 +9,8 @@ import st from "./ObjectsOverlay.module.css";
 export interface ObjectsOverlayProps {
     /** Array of recognized objects to display with bounding boxes */
     recogObjects?: IRecognizedObject[];
+    /** Optional CSS class name to append to the component's outer containment element */
+    className?: string;
 }
 
 /**
@@ -22,7 +24,10 @@ export interface ObjectsOverlayProps {
  * - With props: Pass recogObjects directly
  * - With provider: Wrap in HubStateProvider and objects will be automatically populated from recognition state
  */
-export function ObjectsOverlay({ recogObjects }: ObjectsOverlayProps) {
+export function ObjectsOverlay({
+    recogObjects,
+    className,
+}: ObjectsOverlayProps) {
     // Try to get hub state from context (will be null if not in provider)
     const hubState = useContext(HubStateContext);
 
@@ -56,5 +61,5 @@ export function ObjectsOverlay({ recogObjects }: ObjectsOverlayProps) {
             </div>,
         );
     }
-    return <div className={st.wrapper}>{elements}</div>;
+    return <div className={`${st.wrapper} ${className || ""}`}>{elements}</div>;
 }

--- a/src/components/ObjectsOverlay/ObjectsOverlay.tsx
+++ b/src/components/ObjectsOverlay/ObjectsOverlay.tsx
@@ -61,5 +61,9 @@ export function ObjectsOverlay({
             </div>,
         );
     }
-    return <div className={`${st.wrapper} ${className || ""}`}>{elements}</div>;
+    return (
+        <div className={`${st.bbrObjectsOverlay} ${className || ""}`}>
+            {elements}
+        </div>
+    );
 }

--- a/src/components/PanTilt/PanTilt.module.css
+++ b/src/components/PanTilt/PanTilt.module.css
@@ -1,4 +1,4 @@
-.outerContainer {
+.bbrPanTilt {
     position: fixed;
     bottom: -25px;
     right: -30px;

--- a/src/components/PanTilt/PanTilt.tsx
+++ b/src/components/PanTilt/PanTilt.tsx
@@ -143,7 +143,7 @@ export function PanTilt({
 
     return (
         <div
-            className={`${st.outerContainer} ${className || ""}`}
+            className={`${st.bbrPanTilt} ${className || ""}`}
             data-testid="pan-tilt"
         >
             <h4>Pan ({actualAngles?.["pan"].toFixed(1)})</h4>

--- a/src/components/PanTilt/PanTilt.tsx
+++ b/src/components/PanTilt/PanTilt.tsx
@@ -25,6 +25,8 @@ export interface PanTiltProps {
     servoAngles?: Record<string, number>;
     /** Actual current servo angles (pan/tilt) */
     servoActualAngles?: Record<string, number>;
+    /** Optional CSS class name to append to the component's outer containment element */
+    className?: string;
 }
 
 /**
@@ -43,6 +45,7 @@ export function PanTilt({
     servoConfig,
     servoAngles,
     servoActualAngles,
+    className,
 }: PanTiltProps) {
     // Try to get hub state from context (will be null if not in provider)
     const hubState = useContext(HubStateContext);
@@ -139,7 +142,10 @@ export function PanTilt({
     }
 
     return (
-        <div className={st.outerContainer} data-testid="pan-tilt">
+        <div
+            className={`${st.outerContainer} ${className || ""}`}
+            data-testid="pan-tilt"
+        >
             <h4>Pan ({actualAngles?.["pan"].toFixed(1)})</h4>
             <div className={st.servoRange}>
                 <div>{panServo.max_angle}&deg;</div>

--- a/src/components/VideoFeed/VideoFeed.module.css
+++ b/src/components/VideoFeed/VideoFeed.module.css
@@ -1,9 +1,9 @@
-.videoFeedContainer {
+.bbrVideoFeed {
     align-self: center;
     min-width: 100%;
 }
 
-.videoFeedContainer img {
+.bbrVideoFeed img {
     width: 640px;
     object-fit: contain;
 }

--- a/src/components/VideoFeed/VideoFeed.tsx
+++ b/src/components/VideoFeed/VideoFeed.tsx
@@ -7,6 +7,8 @@ import st from "./VideoFeed.module.css";
 export interface VideoFeedProps {
     /** Whether the video feed is currently active and should be displayed */
     isActive: boolean;
+    /** Optional CSS class name to append to the component's outer containment element */
+    className?: string;
 }
 
 /**
@@ -16,7 +18,10 @@ export interface VideoFeedProps {
  * When inactive, it displays a "please stand by" placeholder image to prevent
  * unnecessary network traffic. Handles loading states and connection errors.
  */
-export const VideoFeed: React.FC<VideoFeedProps> = ({ isActive }) => {
+export const VideoFeed: React.FC<VideoFeedProps> = ({
+    isActive,
+    className,
+}) => {
     const [rand] = useState<number>(0);
     const [errorMsg, setErrorMessage] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -59,7 +64,7 @@ export const VideoFeed: React.FC<VideoFeedProps> = ({ isActive }) => {
     // note must always render the img or it endlessly triggers onLoad
 
     return (
-        <div className={st.videoFeedContainer}>
+        <div className={`${st.videoFeedContainer} ${className || ""}`}>
             <img
                 style={imgStyle}
                 alt={alt}

--- a/src/components/VideoFeed/VideoFeed.tsx
+++ b/src/components/VideoFeed/VideoFeed.tsx
@@ -64,7 +64,7 @@ export const VideoFeed: React.FC<VideoFeedProps> = ({
     // note must always render the img or it endlessly triggers onLoad
 
     return (
-        <div className={`${st.videoFeedContainer} ${className || ""}`}>
+        <div className={`${st.bbrVideoFeed} ${className || ""}`}>
             <img
                 style={imgStyle}
                 alt={alt}

--- a/src/components/WebRTCVideoClient/WebRTCVideoClient.module.css
+++ b/src/components/WebRTCVideoClient/WebRTCVideoClient.module.css
@@ -1,0 +1,5 @@
+.bbrWebRTCVideoClientContainer {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}

--- a/src/components/WebRTCVideoClient/WebRTCVideoClient.module.css
+++ b/src/components/WebRTCVideoClient/WebRTCVideoClient.module.css
@@ -1,4 +1,4 @@
-.bbrWebRTCVideoClientContainer {
+.bbrWebRTCVideoClient {
     position: relative;
     width: 100%;
     height: 100%;

--- a/src/components/WebRTCVideoClient/WebRTCVideoClient.tsx
+++ b/src/components/WebRTCVideoClient/WebRTCVideoClient.tsx
@@ -50,7 +50,7 @@ export const WebRTCVideoClient: React.FC<WebRTCVideoClientProps> = ({
     }, [audioEnabled]);
 
     return (
-        <div className={`${st.webRTCVideoContainer} ${className || ""}`}>
+        <div className={`${st.bbrWebRTCVideoClient} ${className || ""}`}>
             <video
                 ref={videoRef}
                 autoPlay

--- a/src/components/WebRTCVideoClient/WebRTCVideoClient.tsx
+++ b/src/components/WebRTCVideoClient/WebRTCVideoClient.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useRef } from "react";
 import { WebRTCClient } from "../../utils/webrtcClient";
 
+import st from "./WebRTCVideoClient.module.css";
+
 export interface WebRTCVideoClientProps {
     /** Whether the WebRTC stream is currently active */
     isActive: boolean;
     /** Whether audio should be enabled (unmuted) */
     audioEnabled: boolean;
+    /** Optional CSS class name to append to the component's outer containment element */
+    className?: string;
 }
 
 /**
@@ -18,6 +22,7 @@ export interface WebRTCVideoClientProps {
 export const WebRTCVideoClient: React.FC<WebRTCVideoClientProps> = ({
     isActive,
     audioEnabled,
+    className,
 }) => {
     const videoRef = useRef<HTMLVideoElement>(null);
     const audioRef = useRef<HTMLAudioElement>(null);
@@ -45,7 +50,7 @@ export const WebRTCVideoClient: React.FC<WebRTCVideoClientProps> = ({
     }, [audioEnabled]);
 
     return (
-        <div style={{ position: "relative", width: "100%", height: "100%" }}>
+        <div className={`${st.webRTCVideoContainer} ${className || ""}`}>
             <video
                 ref={videoRef}
                 autoPlay


### PR DESCRIPTION
- Adds optional className prop to ObjectsOverlay, PanTilt, VideoFeed, and WebRTCVideoClient components. The className is appended to each component's outermost element, allowing external CSS module classes to override component styles.
- Also adds human identifiable classnames to all of the components of this lib
